### PR TITLE
Support dumping kernel modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+*.o
+*.vpk
+*.bin
+*.sfo
+*.elf
+*.velf
+*.skprx

--- a/Makefile
+++ b/Makefile
@@ -3,18 +3,20 @@ TARGET = mDump
 PSVITAIP = 192.168.1.115
 
 MAIN_OBJS = main.o graphics.o font.o
+PLUGIN_OBJS = kernel.o
 HEADERS = $(wildcard *.h)
 
 LIBS = -lSceDisplay_stub -lSceGxm_stub -lSceCtrl_stub -lSceSysmodule_stub
+PLUGIN_LIBS = -Llibtaihen_stub.a -lSceSysclibForDriver_stub -lSceModulemgrForKernel_stub -lSceIofilemgrForDriver_stub
 
 PREFIX  = arm-vita-eabi
 CC      = $(PREFIX)-gcc
 CFLAGS  = -Wl,-q -Wall -O3
 ASFLAGS = $(CFLAGS)
 
-all: $(TARGET).vpk
+all: mDump.vpk kDump.skprx
 
-%.vpk: eboot.bin
+mDump.vpk: eboot.bin
 	vita-mksfoex -s TITLE_ID=$(TITLE_ID) "$(TARGET)" param.sfo
 	vita-pack-vpk -s param.sfo -b eboot.bin $@
 
@@ -27,8 +29,17 @@ mDump.velf: mDump.elf
 mDump.elf: $(MAIN_OBJS)
 	$(CC) $(CFLAGS) $^ $(LIBS) -o $@
 
+kDump.skprx: kDump.velf
+	vita-make-fself $< $@
+
+kDump.velf: kDump.elf
+	vita-elf-create -e exports.yml $< $@
+
+kDump.elf: $(PLUGIN_OBJS)
+	$(CC) $(CFLAGS) $^ $(PLUGIN_LIBS) -o $@ -nostdlib
+
 clean:
-	@rm -rf *.velf *.elf *.vpk $(MAIN_OBJS) param.sfo eboot.bin
+	@rm -rf *.velf *.elf *.vpk *.skprx $(MAIN_OBJS) $(PLUGIN_OBJS) param.sfo eboot.bin
 
 send: eboot.bin
 	curl -T eboot.bin ftp://$(PSVITAIP):1337/ux0:/app/$(TITLE_ID)/

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ TITLE_ID = NIDUMP001
 TARGET = mDump
 PSVITAIP = 192.168.1.115
 
-OBJS = $(patsubst %.c, %.o, $(wildcard *.c))
+MAIN_OBJS = main.o graphics.o font.o
 HEADERS = $(wildcard *.h)
 
 LIBS = -lSceDisplay_stub -lSceGxm_stub -lSceCtrl_stub -lSceSysmodule_stub
@@ -21,14 +21,14 @@ all: $(TARGET).vpk
 eboot.bin: $(TARGET).velf
 	vita-make-fself $< eboot.bin
 
-%.velf: %.elf
+mDump.velf: mDump.elf
 	vita-elf-create $< $@
 
-%.elf: $(OBJS)
+mDump.elf: $(MAIN_OBJS)
 	$(CC) $(CFLAGS) $^ $(LIBS) -o $@
 
 clean:
-	@rm -rf *.velf *.elf *.vpk $(OBJS) param.sfo eboot.bin
+	@rm -rf *.velf *.elf *.vpk $(MAIN_OBJS) param.sfo eboot.bin
 
 send: eboot.bin
 	curl -T eboot.bin ftp://$(PSVITAIP):1337/ux0:/app/$(TITLE_ID)/

--- a/exports.yml
+++ b/exports.yml
@@ -1,0 +1,8 @@
+vita_dump:
+  attributes: 0
+  version:
+    major: 1
+    minor: 1
+  main:
+    start: module_start
+    stop: module_stop

--- a/graphics.c
+++ b/graphics.c
@@ -74,7 +74,7 @@ void psvDebugScreenInit() {
 
 	g_vram_base = base;
 
-	int ret = sceDisplaySetFrameBuf(&framebuf, SCE_DISPLAY_UPDATETIMING_NEXTVSYNC);
+	sceDisplaySetFrameBuf(&framebuf, SCE_DISPLAY_UPDATETIMING_NEXTVSYNC);
 
 	g_fg_color = 0xFFFFFFFF;
 	g_bg_color = 0x00000000;

--- a/kernel.c
+++ b/kernel.c
@@ -1,0 +1,116 @@
+#include <stdio.h>
+#include <string.h>
+#include <taihen.h>
+#include <psp2kern/kernel/modulemgr.h>
+#include <psp2kern/kernel/threadmgr.h>
+#include <psp2kern/kernel/sysmem.h>
+#include <psp2kern/io/fcntl.h>
+
+#define DUMP_PATH "ux0:dump/"
+#define LOG_FILE DUMP_PATH "kplugin_log.txt"
+
+static void log_reset();
+static void log_write(const char *buffer, size_t length);
+
+#define LOG(...) \
+	do { \
+		char buffer[256]; \
+		snprintf(buffer, sizeof(buffer), ##__VA_ARGS__); \
+		log_write(buffer, strlen(buffer)); \
+	} while (0)
+
+static void dump_region(const char *filename, void *addr, unsigned int size)
+{
+	SceUID fd;
+
+	if (!(fd = sceIoOpenForDriver(filename, SCE_O_WRONLY | SCE_O_CREAT | SCE_O_TRUNC, 6))) {
+		LOG("Error opening %s\n", filename);
+		return;
+	}
+
+	sceIoWriteForDriver(fd, addr, size);
+
+	sceIoCloseForDriver(fd);
+}
+
+void _start() __attribute__ ((weak, alias ("module_start")));
+
+#define MOD_LIST_SIZE 0x80
+
+int module_start(SceSize argc, const void *args)
+{
+	int i, j;
+	int ret;
+	size_t num;
+	SceKernelModuleInfo modinfo;
+	SceUID modlist[MOD_LIST_SIZE];
+
+	log_reset();
+
+	LOG("kplugin by xerpi\n");
+
+	memset(modlist, 0, sizeof(modlist));
+
+	num = MOD_LIST_SIZE;
+	ret = sceKernelGetModuleListForKernel(KERNEL_PID, 0x80000001, 1, modlist, &num);
+	if (ret < 0)
+		LOG("Error getting the module list\n");
+
+	LOG("Found %d modules.\n", num);
+
+	for (i = 0; i < num; i++) {
+		memset(&modinfo, 0, sizeof(modinfo));
+
+		ret = sceKernelGetModuleInfoForKernel(KERNEL_PID, modlist[i], &modinfo);
+		if (ret < 0) {
+			LOG("Error getting the module info for module: %d\n", i);
+			continue;
+		}
+
+		LOG("Module %d name: %s\n", i, modinfo.module_name);
+
+		for (j = 0; j < 4; j++) {
+			char path[128];
+			SceKernelSegmentInfo *seginfo = &modinfo.segments[j];
+
+			if (seginfo->size != sizeof(*seginfo))
+				continue;
+
+			snprintf(path, sizeof(path), DUMP_PATH "%s_0x%08X_seg%d.bin",
+				modinfo.module_name, (uintptr_t)seginfo->vaddr, j);
+
+			dump_region(path, seginfo->vaddr, seginfo->memsz);
+		}
+	}
+
+	return SCE_KERNEL_START_SUCCESS;
+}
+
+int module_stop(SceSize argc, const void *args)
+{
+	return SCE_KERNEL_STOP_SUCCESS;
+}
+
+void log_reset()
+{
+	SceUID fd = sceIoOpenForDriver(LOG_FILE,
+		SCE_O_WRONLY | SCE_O_CREAT | SCE_O_TRUNC, 6);
+	if (fd < 0)
+		return;
+
+	sceIoCloseForDriver(fd);
+}
+
+void log_write(const char *buffer, size_t length)
+{
+	extern int sceIoMkdirForDriver(const char *, int);
+	sceIoMkdirForDriver(DUMP_PATH, 6);
+
+	SceUID fd = sceIoOpenForDriver(LOG_FILE,
+		SCE_O_WRONLY | SCE_O_CREAT | SCE_O_APPEND, 6);
+	if (fd < 0)
+		return;
+
+	sceIoWriteForDriver(fd, buffer, length);
+	sceIoCloseForDriver(fd);
+}

--- a/main.c
+++ b/main.c
@@ -9,7 +9,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <psp2/moduleinfo.h>
 #include <psp2/io/fcntl.h>
 #include <psp2/io/dirent.h>
 #include <psp2/kernel/threadmgr.h>
@@ -27,7 +26,7 @@
 
 const char *outDir = "ux0:/dump";
 
-int removePath(char *path, uint32_t *value, uint32_t max, void (* SetProgress)(uint32_t value, uint32_t max), int (* cancelHandler)()) {
+int removePath(const char *path, uint32_t *value, uint32_t max, void (* SetProgress)(uint32_t value, uint32_t max), int (* cancelHandler)()) {
 	SceUID dfd = sceIoDopen(path);
 	if (dfd >= 0) {
 		int res = 0;
@@ -277,7 +276,7 @@ void dumpModule(SceUID id) {
 		doDump(id, &info);
 	}
 
-}	
+}
 
 void newModules() {
 	SceUInt16 i = 0;
@@ -299,7 +298,7 @@ int main(int argc, char **argv) {
 
 
 	int result = 0;
-	
+
 	if ((result = sceIoOpen(outDir,SCE_O_RDONLY, 0777)) < 0) {
 		result = sceIoMkdir(outDir, 0777);
 
@@ -332,11 +331,11 @@ _continue_:
 		dumpModule(mList[i]);
 	*/
 	psvDebugScreenPrintf("Dumping modules by name\n");
-	
+
 	//dumpModuleByPath("1e6c89bb6fd70485", "pd0:app/NPXS10007/sce_module/libc.suprx");
 	//dumpModuleByPath("3c3b85ca044fab22", "pd0:app/NPXS10007/sce_module/libfios2.suprx");
 	//dumpModuleByPath("9ce10e890f276561", "pd0:app/NPXS10007/sce_module/libult.suprx");
-	
+
 	//251 USERMODULES
 	dumpModuleByPath("2800000000028005", "os0:us/avcodec_us.suprx");
 	dumpModuleByPath("280000000002800a", "os0:us/driver_us.suprx");
@@ -593,12 +592,12 @@ _continue_:
 	dumpModuleByPath("2800000000000001", "vs0:/vsh/shell/shell.self");
 	dumpModuleByPath("2800000000020025", "vs0:/vsh/shell/telephony/initial_check/tel_initial_check_plugin.suprx");
 
-	
-	
+
+
 	psvDebugScreenPrintf("Done\n");
 
-_exit_:
-	
+//_exit_:
+
 	while (1) {}
 
 	sceKernelExitProcess(0);


### PR DESCRIPTION
- fix build error & warning on latest sdk
- @xerpi made all dump codes
- modified makefile, and now require taihen library for `make all`